### PR TITLE
Respect a pytest DeprecationWarning

### DIFF
--- a/dirtyjson/attributed_containers.py
+++ b/dirtyjson/attributed_containers.py
@@ -4,7 +4,7 @@ http://code.activestate.com/recipes/576693/
 
 """
 try:
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
     py_level = 3
 except ImportError:
     # noinspection PyUnresolvedReferences,PyCompatibility


### PR DESCRIPTION
Respect a pytest DeprecationWarning for collections.abc:

../../usr/local/lib/python3.7/dist-packages/dirtyjson/attributed_containers.py:7
  /usr/local/lib/python3.7/dist-packages/dirtyjson/attributed_containers.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping as DictMixin

-- Docs: https://docs.pytest.org/en/stable/warnings.html